### PR TITLE
Allow / characters in the title of a runbook

### DIFF
--- a/lib/runbook/helpers/tmux_helper.rb
+++ b/lib/runbook/helpers/tmux_helper.rb
@@ -41,7 +41,7 @@ module Runbook::Helpers
     end
 
     def _slug(title)
-      title.titleize.gsub(/\s+/, "").underscore.dasherize
+      title.titleize.gsub(/[\/\s]+/, "").underscore.dasherize
     end
 
     def _all_panes_exist?(stored_layout)

--- a/lib/runbook/util/repo.rb
+++ b/lib/runbook/util/repo.rb
@@ -27,7 +27,7 @@ module Runbook::Util
     end
 
     def self._slug(title)
-      title.titleize.gsub(/\s+/, "").underscore.dasherize
+      title.titleize.gsub(/[\/\s]+/, "").underscore.dasherize
     end
 
     def self.register_save_repo_hook(base)

--- a/lib/runbook/util/stored_pose.rb
+++ b/lib/runbook/util/stored_pose.rb
@@ -25,7 +25,7 @@ module Runbook::Util
     end
 
     def self._slug(title)
-      title.titleize.gsub(/\s+/, "").underscore.dasherize
+      title.titleize.gsub(/[\/\s]+/, "").underscore.dasherize
     end
 
     def self.register_save_pose_hook(base)

--- a/spec/helpers/tmux_helper_spec.rb
+++ b/spec/helpers/tmux_helper_spec.rb
@@ -117,7 +117,6 @@ RSpec.describe Runbook::Helpers::TmuxHelper do
       "my-runbook-title",
       "other-runbook-title",
       "some-runbook-title",
-      "some-runbook-title",
     ] }
 
     it "returns a slugified version of its argument" do

--- a/spec/helpers/tmux_helper_spec.rb
+++ b/spec/helpers/tmux_helper_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe Runbook::Helpers::TmuxHelper do
     let(:inputs) { [
       "My Runbook Title",
       "my Runbook title",
+      "my/Runbook/title",
       "OTHER Runbook TITLE",
       "some      Runbook TITLE",
     ] }
@@ -113,7 +114,9 @@ RSpec.describe Runbook::Helpers::TmuxHelper do
     let(:outputs) { [
       "my-runbook-title",
       "my-runbook-title",
+      "my-runbook-title",
       "other-runbook-title",
+      "some-runbook-title",
       "some-runbook-title",
     ] }
 

--- a/spec/util/repo_spec.rb
+++ b/spec/util/repo_spec.rb
@@ -66,6 +66,18 @@ RSpec.describe Runbook::Util::Repo, type: :aruba do
       Runbook::Util::Repo.load(metadata)
       expect(metadata[:repo]).to eq(repo)
     end
+
+    context "when the title has invalid characters" do
+      let(:book_title) { "My/Amazing/Runbook" }
+
+      it "saves the repo" do
+        Runbook::Util::Repo.save(repo, book_title: book_title)
+        metadata[:repo] = {}
+
+        Runbook::Util::Repo.load(metadata)
+        expect(metadata[:repo]).to eq(repo)
+      end
+    end
   end
 
   describe "self.delete" do

--- a/spec/util/stored_pose_spec.rb
+++ b/spec/util/stored_pose_spec.rb
@@ -57,6 +57,17 @@ RSpec.describe Runbook::Util::StoredPose, type: :aruba do
       pose = Runbook::Util::StoredPose.load(metadata)
       expect(pose).to eq(current_pose)
     end
+
+    context "when the title has invalid characters" do
+      let(:book_title) { "My/Amazing/Runbook" }
+
+      it "saves the current position" do
+        Runbook::Util::StoredPose.save(current_pose, book_title: book_title)
+
+        pose = Runbook::Util::StoredPose.load(metadata)
+        expect(pose).to eq(current_pose)
+      end
+    end
   end
 
   describe "self.delete" do


### PR DESCRIPTION
Current implementation only omits spaces from the regular expression
that generates a file path for a given runbook.

This change allows for the / character in the runbook title which allows
clients to use a folder-like structure for their runbooks.