### PR TITLE
Let markdown view backtick "into"-targets (indicating 'codiness')

### DIFF
--- a/lib/runbook/views/markdown.rb
+++ b/lib/runbook/views/markdown.rb
@@ -23,7 +23,7 @@ module Runbook::Views
 
     def self.runbook__statements__ask(object, output, metadata)
       default_msg = object.default ?  " (default: #{object.default})" : ""
-      output << "   #{object.prompt} into #{object.into}#{default_msg}\n\n"
+      output << "   #{object.prompt} into `#{object.into}#{default_msg}`\n\n"
     end
 
     def self.runbook__statements__assert(object, output, metadata)
@@ -41,11 +41,11 @@ module Runbook::Views
     end
 
     def self.runbook__statements__capture(object, output, metadata)
-      output << "   capture: `#{object.cmd}` into #{object.into}\n\n"
+      output << "   capture: `#{object.cmd}` into `#{object.into}`\n\n"
     end
 
     def self.runbook__statements__capture_all(object, output, metadata)
-      output << "   capture_all: `#{object.cmd}` into #{object.into}\n\n"
+      output << "   capture_all: `#{object.cmd}` into `#{object.into}`\n\n"
     end
 
     def self.runbook__statements__command(object, output, metadata)

--- a/lib/runbook/views/markdown.rb
+++ b/lib/runbook/views/markdown.rb
@@ -23,7 +23,7 @@ module Runbook::Views
 
     def self.runbook__statements__ask(object, output, metadata)
       default_msg = object.default ?  " (default: #{object.default})" : ""
-      output << "   #{object.prompt} into `#{object.into}#{default_msg}`\n\n"
+      output << "   #{object.prompt} into `#{object.into}`#{default_msg}\n\n"
     end
 
     def self.runbook__statements__assert(object, output, metadata)


### PR DESCRIPTION
As the "into" targets of capture, capture_all and ask are code-related, render them in backticks (indicating code).
Probably it would even be desirable to add an @ before (as these are local variables in code paths later in the runbook).