### PR TITLE
Allow un-nested steps to be skipped

### DIFF
--- a/lib/runbook/run.rb
+++ b/lib/runbook/run.rb
@@ -233,9 +233,9 @@ module Runbook
           return
         when :skip
           position = metadata[:position]
-          current_step = position.split(".")[-1].to_i
-          new_step = current_step + 1
-          start_at = position.gsub(/\.#{current_step}$/, ".#{new_step}")
+          split_position = position.split(".")
+          new_step = (split_position.pop.to_i + 1).to_s
+          start_at = (split_position <<  new_step).join(".")
           metadata[:start_at] = start_at
         when :jump
           result = toolbox.ask("What position would you like to jump to?")

--- a/spec/run_spec.rb
+++ b/spec/run_spec.rb
@@ -132,10 +132,22 @@ RSpec.describe "Runbook::Run" do
       end
 
       context "when :skip" do
-        it "skips the step" do
-          expect(toolbox).to receive(:expand).and_return(:skip)
-          subject.execute(object, metadata)
-          expect(metadata[:start_at]).to eq("1.2")
+        context "when step is top level" do
+          let(:metadata_override) { {position: "1", paranoid: true} }
+          it "skips the step" do
+            expect(toolbox).to receive(:expand).and_return(:skip)
+            subject.execute(object, metadata)
+            expect(metadata[:start_at]).to eq("2")
+          end
+        end
+
+        context "when step is nested" do
+          let(:metadata_override) { {position: "1.2.1.2", paranoid: true} }
+          it "skips the step" do
+            expect(toolbox).to receive(:expand).and_return(:skip)
+            subject.execute(object, metadata)
+            expect(metadata[:start_at]).to eq("1.2.1.3")
+          end
         end
       end
 


### PR DESCRIPTION
This PR contains a small edit to enable steps not nested in other entities to be skipped. Addresses issue https://github.com/braintree/runbook/issues/24