### PR TITLE
Use File.exist? instead of File.exists?

### DIFF
--- a/lib/runbook/helpers/tmux_helper.rb
+++ b/lib/runbook/helpers/tmux_helper.rb
@@ -5,7 +5,7 @@ module Runbook::Helpers
     def setup_layout(structure, runbook_title:)
       _remove_stale_layouts
       layout_file = _layout_file(_slug(runbook_title))
-      if File.exists?(layout_file)
+      if File.exist?(layout_file)
         stored_layout = ::YAML::load_file(layout_file)
         if _all_panes_exist?(stored_layout)
           return stored_layout

--- a/lib/runbook/util/repo.rb
+++ b/lib/runbook/util/repo.rb
@@ -6,7 +6,7 @@ module Runbook::Util
     def self.load(metadata)
       title = metadata[:book_title]
       file = _file(title)
-      if File.exists?(file)
+      if File.exist?(file)
         msg = "Repo file #{file} detected. Loading previous state..."
         metadata[:toolbox].output(msg)
         metadata[:repo] = ::YAML::load_file(file)

--- a/lib/runbook/util/stored_pose.rb
+++ b/lib/runbook/util/stored_pose.rb
@@ -6,7 +6,7 @@ module Runbook::Util
     def self.load(metadata)
       title = metadata[:book_title]
       file = _file(title)
-      if File.exists?(file)
+      if File.exist?(file)
         ::YAML::load_file(file)
       end
     end

--- a/spec/helpers/tmux_helper_spec.rb
+++ b/spec/helpers/tmux_helper_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Runbook::Helpers::TmuxHelper do
 
     context "when layout_file exists" do
       before(:each) do
-        expect(File).to receive(:exists?).with(layout_file).and_return(true)
+        expect(File).to receive(:exist?).with(layout_file).and_return(true)
       end
 
       context "when all panes exist" do
@@ -61,7 +61,7 @@ RSpec.describe Runbook::Helpers::TmuxHelper do
 
     context "when layout file does not exist" do
       before(:each) do
-        expect(File).to receive(:exists?).with(layout_file).and_return(false)
+        expect(File).to receive(:exist?).with(layout_file).and_return(false)
       end
 
       it "invokes _setup_layout" do


### PR DESCRIPTION
Fix deprecation warning.
`File.exists?` is deprecated since ruby 2.1.

```sh
$ ruby -w -e "File.exists?('foo')"
-e:1: warning: File.exists? is deprecated; use File.exist? instead
```