### PR TITLE
Update method_source dependency in runbook.gemspec

### DIFF
--- a/runbook.gemspec
+++ b/runbook.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "activesupport", ">= 5.0.1.x", "< 7.0"
-  spec.add_runtime_dependency "method_source", "~> 0.9"
+  spec.add_runtime_dependency "method_source", "~> 1.0"
   spec.add_runtime_dependency "sshkit", "1.21.0"
   spec.add_runtime_dependency "sshkit-sudo", "~> 0.1"
   spec.add_runtime_dependency "airbrussh", "~> 1.4"


### PR DESCRIPTION
Update method_source dependency version constraint to "~> 1.0"

This is needed to be able to use runbook together with the newest version of pry.