### PR TITLE
Remove v1.0 deprecation warnings from specs

### DIFF
--- a/lib/runbook.rb
+++ b/lib/runbook.rb
@@ -2,6 +2,7 @@ require "tmpdir"
 require "yaml"
 require "thread"
 
+require "active_support/deprecation"
 require "active_support/inflector"
 require "method_source"
 require "pastel"

--- a/spec/cli/init_spec.rb
+++ b/spec/cli/init_spec.rb
@@ -52,7 +52,6 @@ RSpec.describe "runbook install", type: :aruba do
   let(:command) { "runbook install" }
   let(:installation_output) {
     [
-      "DEPRECATION WARNING: install is deprecated and will be removed from Runbook 1.0 \\(use init instead\\) \\(called from",
       "create  Runbookfile",
       "create  runbooks",
       "create  lib/runbook",


### PR DESCRIPTION
This PR also fixes a missing explicit `active_support/deprecation` requirement bug.

This addresses issue https://github.com/braintree/runbook/issues/41

@coopergillan