### PR TITLE
Add metadata argument that saves TMUX panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ Metadata at execution time is structured as follows:
   noop: false, # A boolean indicating if you are running in noop mode. ruby_command blocks are never evaluated in noop mode
   auto: false, # A boolean indicating if you are running in auto mode
   paranoid: true, # A boolean indicating if you are running in paranoid mode (prompting before each step)
+  keep_panes: false, # A boolean indicating whether panes should be kept open after completion
   start_at: 0, # A string representing the step where nodes should start being processed
   toolbox: Runbook::Toolbox.new, # A collection of methods to invoke side-effects such as printing and collecting input
   layout_panes: {}, # A map of pane names to pane ids. `layout_panes` is used by the `tmux_command` to identify which tmux pane to send the command to

--- a/lib/runbook/run.rb
+++ b/lib/runbook/run.rb
@@ -258,7 +258,7 @@ module Runbook
         :after,
         Runbook::Entities::Book,
       ) do |object, metadata|
-        next if metadata[:noop] || metadata[:layout_panes].none?
+        next if metadata[:noop] || metadata[:layout_panes].none? || metadata[:keep_panes]
         if metadata[:auto]
           metadata[:toolbox].output("Killing all opened tmux panes...")
           kill_all_panes(metadata[:layout_panes])

--- a/lib/runbook/runner.rb
+++ b/lib/runbook/runner.rb
@@ -11,6 +11,7 @@ module Runbook
       noop: false,
       auto: false,
       paranoid: true,
+      keep_panes: false,
       start_at: "0"
     )
       run = "Runbook::Runs::#{run.to_s.camelize}".constantize
@@ -21,6 +22,7 @@ module Runbook
         paranoid: Util::Glue.new(paranoid),
         start_at: Util::Glue.new(start_at || "0"),
         toolbox: Util::Glue.new(toolbox),
+        keep_panes: keep_panes,
         book_title: book.title,
       }).
       merge(Runbook::Entities::Book.initial_run_metadata).

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -488,6 +488,22 @@ Note: Run me last
           and_return(layout_panes)
         end
 
+        context "with keep_panes: true" do
+
+          it "does not kill all panes" do
+            expect(
+              Runbook::Runs::SSHKit
+            ).to_not receive(:kill_all_panes)
+
+            runner.run(
+              run: run,
+              auto: false,
+              paranoid: false,
+              keep_panes: true
+            )
+          end
+        end
+
         context "with auto: true" do
           it "kills all panes without prompting" do
             expect_any_instance_of(


### PR DESCRIPTION
Heyo,

I often want a half way between auto and not auto.  I will often do something like:

```
git ls-files --exclude-standard -cmod data | entr run_runbook_that_opens_tmux_panes
```

do re-run my runbook on every invocation.  But that has problems if I either force closing all panes, or if I have to interact with it every time.  This option will allow you to add `save_panes: true` to your metadata and it will just exit quietly after a run, leaving your tmux windows open to check output.  It, like runbook always does, will then reuse the panes for the next invocation.