### PR TITLE
GH-48 - Switch CI to Gihtub Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -29,7 +29,6 @@ jobs:
           - 2.6
           - 2.7
           - '3.0'  # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-          - 3.1
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,43 @@
+name: Ruby CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        exclude:
+          - ruby-version: 2.3.8
+            gemfile: gemfiles/activesupport_6.gemfile
+          - ruby-version: 2.4.10
+            gemfile: gemfiles/activesupport_6.gemfile
+        gemfile:
+          - gemfiles/activesupport_5.gemfile
+          - gemfiles/activesupport_6.gemfile
+        ruby-version:
+          - 2.3.8
+          - 2.4.10
+          - 2.5.8
+          - 2.6.6
+          - 2.7.2
+          - '3.0.0' # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
+    env:
+      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rake spec_all

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,10 +25,11 @@ jobs:
         ruby-version:
           - 2.3.8
           - 2.4.10
-          - 2.5.8
-          - 2.6.6
-          - 2.7.2
-          - '3.0.0' # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
+          - 2.5
+          - 2.6
+          - 2.7
+          - '3.0'  # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
+          - 3.1
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:


### PR DESCRIPTION
### What

Set up a Github Actions workflow to build and run tests for `runbook`

### Why

* [travis-ci.org is migrating to travis.com soon](https://docs.travis-ci.com/user/migrate/open-source-on-travis-ci-com/)
* Docker is limiting image pulls via current Travis builds ([example from current `master` build here](https://travis-ci.org/github/braintree/runbook/jobs/771913797))
* [Github Actions is built in to Github projects like `runbook`](https://docs.github.com/en/actions)

### A note on Travis

Should these changes prove sufficient to build and run tests, [`travis.yml` file](./travis.yml) can be removed in a subsequent pull request.

### A note on actually running the workflows

I opened https://github.com/coopergillan/runbook/pull/1 in my fork and it has passed successfully. I am wondering if it's because the pull requests are coming from forks and that builds will only run if they are opened directly in the repo. If so, this appears to be fairly new behavior since [merged pull requests from the last several years or so](https://github.com/braintree/runbook/pulls?q=is%3Apr+is%3Amerged+) all had builds run for forks 🤔

Closes #48

@ClashTheBunny @hollabaq86