### PR TITLE
Upgrade Thor

### DIFF
--- a/runbook.gemspec
+++ b/runbook.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "sshkit", "1.21.0"
   spec.add_runtime_dependency "sshkit-sudo", "~> 0.1"
   spec.add_runtime_dependency "airbrussh", "~> 1.4"
-  spec.add_runtime_dependency "thor", "~> 0.20"
+  spec.add_runtime_dependency "thor", "~> 1.0"
   spec.add_runtime_dependency "tty-progressbar", "~> 0.14"
   spec.add_runtime_dependency "tty-prompt", "~> 0.20"
 


### PR DESCRIPTION
This patch raises the thor version to `~> 1.0`.
[Rails 6.1 requires thor `~> 1.0`](https://rubygems.org/gems/railties), so it probably makes sense for us to also up our requirement.

```
 In Gemfile:
    rails (~> 6.1.4) was resolved to 6.1.4.1, which depends on
      railties (= 6.1.4.1) was resolved to 6.1.4.1, which depends on
        thor (~> 1.0)
```