### PR TITLE
GH-48 - Pin latest Ubuntu version

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -29,7 +29,6 @@ jobs:
           - 2.6
           - 2.7
           - '3.0'  # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-          - 3.1
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -29,6 +29,7 @@ jobs:
           - 2.6
           - 2.7
           - '3.0'  # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
+          - 3.1
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
# Description

* Pin the latest Ubuntu version to ensure repeatable builds (latest version taken from [`actions/virtual-environments`](https://github.com/actions/virtual-environments#available-environments))
* ~Run builds for Ruby 3.1 also, the [latest minor version of Ruby](https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/) as of early 2022~ - see https://github.com/braintree/runbook/issues/56 to add support for Ruby 3.1

Thanks to @hollabaq86 for some of these suggestions over in https://github.com/coopergillan/runbook/pull/1

@ClashTheBunny