### PR TITLE
Require Bundler in Project Generator

### DIFF
--- a/lib/runbook/generators/project/project.rb
+++ b/lib/runbook/generators/project/project.rb
@@ -1,3 +1,5 @@
+require "bundler"
+
 module Runbook::Generators
   class Project < Thor::Group
     include ::Runbook::Generators::Base


### PR DESCRIPTION
When following the setup steps in the readme to generate a new project I run into the following error:

```
uninitialized constant Runbook::Generators::Project::Bundler
```

This is due to making use of `Bundler::VERSION` but not requiring `bundler` before doing so.

Steps to reproduce:

1. Be **outside** of a ruby project.
2. Run `gem install runbook`.
3. Run `runbook generate project my_project`